### PR TITLE
Clean up server notebook code and util functions

### DIFF
--- a/notebooks/example_server.ipynb
+++ b/notebooks/example_server.ipynb
@@ -14,12 +14,22 @@
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "ojSUEp5MDFRo"
-      },
+      "metadata": {},
       "outputs": [],
       "source": [
+        "import os\n",
+        "from google.colab import userdata\n",
         "from gr_tradinggame.coding.server import GameServer"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "NGROK_TOKEN = userdata.get(\"NGROK_AUTHTOKEN\")\n",
+        "!ngrok config add-authtoken $NGROK_TOKEN"
       ]
     },
     {
@@ -30,7 +40,7 @@
       },
       "outputs": [],
       "source": [
-        "server = GameServer('2xKdM2iD98QgKJz9Pw8DQh9DalR_4EEYGbDiMWSdQR5os7Qa2')  # see https://dashboard.ngrok.com/get-started/your-authtoken\n",
+        "server = GameServer()\n",
         "server.run()"
       ]
     },
@@ -72,15 +82,15 @@
     },
     {
       "cell_type": "code",
-      "source": [
-        "game = CodingGame(additional_functions=bots, random_draw_function='b')\n",
-        "game.play()"
-      ],
+      "execution_count": null,
       "metadata": {
         "id": "f0kuiKW1r8RM"
       },
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "game = CodingGame(additional_functions=bots, random_draw_function='b')\n",
+        "game.play()"
+      ]
     },
     {
       "cell_type": "code",

--- a/notebooks/example_server.ipynb
+++ b/notebooks/example_server.ipynb
@@ -17,7 +17,6 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "import os\n",
         "from google.colab import userdata\n",
         "from gr_tradinggame.coding.server import GameServer"
       ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ description = "Add your description here"
 readme = "README.md"
 authors = [
     { name = "Soeren Wolfers", email = "soeren.wolfers@gresearch.com" }
+    { name = "Ajay Mittal", email = "ajaymittal2001@gmail.com" }
 ]
 requires-python = ">=3.11"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.13"
 description = "Add your description here"
 readme = "README.md"
 authors = [
-    { name = "Soeren Wolfers", email = "soeren.wolfers@gresearch.com" }
+    { name = "Soeren Wolfers", email = "soeren.wolfers@gresearch.com" },
     { name = "Ajay Mittal", email = "ajaymittal2001@gmail.com" }
 ]
 requires-python = ">=3.11"

--- a/src/gr_tradinggame/coding/server.py
+++ b/src/gr_tradinggame/coding/server.py
@@ -70,5 +70,5 @@ class GameServer:
 
     def run(self, force_restart=False):
         server_id = get_url(force_restart)
-        print("Serving", server_id)
+        print('Serving', server_id)
         self.app.run(port=5000)

--- a/src/gr_tradinggame/coding/server.py
+++ b/src/gr_tradinggame/coding/server.py
@@ -11,7 +11,7 @@ from .util import get_url
 
 
 class GameServer:
-    def __init__(self, token):
+    def __init__(self):
         self.name = str(uuid.uuid4())
         self.submission_lock = threading.Lock()
         self.USERNAME = "colabuser"
@@ -67,9 +67,8 @@ class GameServer:
                 indent=4
             ))
             return jsonify({"status": "success"})
-        self.token = token
 
     def run(self, force_restart=False):
-        server_id = get_url(self.token, force_restart)
-        print('Serving', server_id)
+        server_id = get_url(force_restart)
+        print("Serving", server_id)
         self.app.run(port=5000)

--- a/src/gr_tradinggame/coding/util.py
+++ b/src/gr_tradinggame/coding/util.py
@@ -36,6 +36,6 @@ def get_url(force_restart=False):
         r = requests.get(NGROK_API)
         tunnels = r.json()["tunnels"]
         public_url = tunnels[0]["public_url"]
-        return public_url.replace("https://", "").replace("http://", "")
+        return public_url.split('//')[1].split('.ngrok-free.app')[0]
     except Exception as e:
         raise RuntimeError("ngrok tunnel not available") from e

--- a/src/gr_tradinggame/coding/util.py
+++ b/src/gr_tradinggame/coding/util.py
@@ -1,27 +1,41 @@
 import time
-import pyngrok
-from pyngrok import ngrok
 import subprocess
 import requests
+from pyngrok import ngrok, conf
 
+NGROK_API = "http://localhost:4040/api/tunnels"
 
-def get_url(token, force_restart):
-    def kill_and_restart():
-        subprocess.run(["pkill", "ngrok"])
-        ngrok.install_ngrok()
-        subprocess.Popen([pyngrok.conf.get_default().ngrok_path, 'http', '5000', '--authtoken', token], start_new_session=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-        time.sleep(5)
-
-    def try_get_url():
-        response = requests.get("http://localhost:4040/api/tunnels")
-        tunnels = response.json()['tunnels']
-        public_url = tunnels[0]['public_url']
-        return public_url.split('//')[1].split('.ngrok-free.app')[0]
-
-    if force_restart:
-        kill_and_restart()
+def _cleanup_local_tunnels():
     try:
-        return try_get_url()
+        r = requests.get(NGROK_API, timeout=1)
+        for t in r.json().get("tunnels", []):
+            ngrok.disconnect(t["public_url"])
     except Exception:
-        kill_and_restart()
-        return try_get_url()
+        pass
+
+def _ensure_ngrok_running():
+    try:
+        requests.get(NGROK_API, timeout=1)
+    except Exception:
+        ngrok.install_ngrok()
+        subprocess.Popen(
+            [conf.get_default().ngrok_path, "http", "5000"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+        time.sleep(4)
+
+def get_url(force_restart=False):
+    if force_restart:
+        _cleanup_local_tunnels()
+
+    _ensure_ngrok_running()
+
+    try:
+        r = requests.get(NGROK_API)
+        tunnels = r.json()["tunnels"]
+        public_url = tunnels[0]["public_url"]
+        return public_url.replace("https://", "").replace("http://", "")
+    except Exception as e:
+        raise RuntimeError("ngrok tunnel not available") from e

--- a/src/gr_tradinggame/coding/util.py
+++ b/src/gr_tradinggame/coding/util.py
@@ -9,7 +9,9 @@ def _cleanup_local_tunnels():
     try:
         r = requests.get(NGROK_API, timeout=1)
         for t in r.json().get("tunnels", []):
-            ngrok.disconnect(t["public_url"])
+            old_url = t["public_url"]
+            print(f"NOTE: disconnecting and cleaning up {old_url} before serving new session.")
+            ngrok.disconnect(old_url)
     except Exception:
         pass
 
@@ -24,7 +26,7 @@ def _ensure_ngrok_running():
             stderr=subprocess.DEVNULL,
             start_new_session=True,
         )
-        time.sleep(4)
+        time.sleep(5)
 
 def get_url(force_restart=False):
     if force_restart:


### PR DESCRIPTION
Assumes code runs on Google Colab. Cleans up the server notebook code and library code to be a bit more stable and less manual.

Assuming it is fine to get the Ngrok token from the user's account once and once only (token will persist across all sessions and notebooks ever):
- On Colab, open the secrets tab on the left hand side.
- Add a secret with notebook access, with the following:
  - Name: NGROK_AUTHTOKEN
  - Value: token pasted from https://dashboard.ngrok.com/get-started/your-authtoken (just the token, no quote marks etc)

Assumes you only want one server running at once. It will re-use a running instance that already exists so you shouldn't have to force kill sessions on ngrok as there should only be one session running. If you want multiple different servers running at once let me know and I can support that.

I have tested running the server using your token below ([link here](https://github.com/soerenwolfers/gr_tradinggame/compare/main...ajaykm3:gr_tradinggame:ngrok-stability?expand=1#diff-fd6c9aa24f6a8ff14b175004de1c74dd3b1a0123f14513533bd8b4317e7bae41L33) to see what the original token was) which I replace in this PR with the Colab secrets workflow (I set the token value to be the same token that was here)

NOTE: Changes are made to the library source code (server.py, util.py). The library source code is not accessed directly but through a python package (as seen in the line `pip install gr_tradinggame`)
**So this code will only work** if a new package with the library changes is published.

@soerenwolfers let me know if your feature request differs from what is proposed either here or via internal channels.